### PR TITLE
Refactor SecurityHeaderPolicy

### DIFF
--- a/src/AdamBarclay.AspNetCore.SecurityHeaders/SecurityHeaderPolicy.cs
+++ b/src/AdamBarclay.AspNetCore.SecurityHeaders/SecurityHeaderPolicy.cs
@@ -5,58 +5,41 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders
 {
 	internal sealed class SecurityHeaderPolicy
 	{
-		private readonly string contentSecurityPolicy;
-		private readonly string frameOptions;
-		private readonly string referrerPolicy;
-		private readonly string strictTransportSecurity;
+		private readonly (string Name, string Value)[] policies;
+		private readonly (string Name, string Value)[] secureOnlyPolicies;
 
 		internal SecurityHeaderPolicy(
-			string contentSecurityPolicy,
-			string frameOptions,
-			string referrerPolicy,
-			string strictTransportSecurity)
+			(string Name, string Value)[] policies,
+			(string Name, string Value)[] secureOnlyPolicies)
 		{
-			Debug.Assert(contentSecurityPolicy != null);
-			Debug.Assert(contentSecurityPolicy.Length > 0);
-			Debug.Assert(frameOptions != null);
-			Debug.Assert(frameOptions.Length > 0);
-			Debug.Assert(referrerPolicy != null);
-			Debug.Assert(referrerPolicy.Length > 0);
-			Debug.Assert(strictTransportSecurity != null);
-			Debug.Assert(strictTransportSecurity.Length > 0);
+			Debug.Assert(policies != null);
+			Debug.Assert(secureOnlyPolicies != null);
 
-			this.contentSecurityPolicy = contentSecurityPolicy;
-			this.frameOptions = frameOptions;
-			this.referrerPolicy = referrerPolicy;
-			this.strictTransportSecurity = strictTransportSecurity;
+			this.policies = policies;
+			this.secureOnlyPolicies = secureOnlyPolicies;
 		}
 
 		internal void WriteHeaders(IHeaderDictionary headers, bool isHttps)
 		{
 			Debug.Assert(headers != null);
 
-			SecurityHeaderPolicy.SetHeader(headers, "content-security-policy", this.contentSecurityPolicy);
-			SecurityHeaderPolicy.SetHeader(headers, "x-content-type-options", "nosniff");
-			SecurityHeaderPolicy.SetHeader(headers, "x-frame-options", this.frameOptions);
-			SecurityHeaderPolicy.SetHeader(headers, "referrer-policy", this.referrerPolicy);
+			foreach ((var name, var value) in this.policies)
+			{
+				if (!headers.ContainsKey(name))
+				{
+					headers[name] = value;
+				}
+			}
 
 			if (isHttps)
 			{
-				SecurityHeaderPolicy.SetHeader(headers, "strict-transport-security", this.strictTransportSecurity);
-			}
-		}
-
-		private static void SetHeader(IHeaderDictionary headers, string name, string value)
-		{
-			Debug.Assert(headers != null);
-			Debug.Assert(name != null);
-			Debug.Assert(name.Length > 0);
-			Debug.Assert(value != null);
-			Debug.Assert(value.Length > 0);
-
-			if (!headers.ContainsKey(name))
-			{
-				headers[name] = value;
+				foreach ((var name, var value) in this.secureOnlyPolicies)
+				{
+					if (!headers.ContainsKey(name))
+					{
+						headers[name] = value;
+					}
+				}
 			}
 		}
 	}

--- a/src/AdamBarclay.AspNetCore.SecurityHeaders/SecurityHeaderPolicyBuilder.cs
+++ b/src/AdamBarclay.AspNetCore.SecurityHeaders/SecurityHeaderPolicyBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using AdamBarclay.AspNetCore.SecurityHeaders.PolicyBuilders;
 
 namespace AdamBarclay.AspNetCore.SecurityHeaders
@@ -6,15 +7,15 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders
 	/// <summary>The security header policy builder.</summary>
 	public sealed class SecurityHeaderPolicyBuilder
 	{
-		private readonly FrameOptionsBuilder frameOptionsBuilder;
-		private readonly ReferrerPolicyBuilder referrerPolicyBuilder;
-		private readonly StrictTransportSecurityBuilder strictTransportSecurityBuilder;
+		private FrameOptionsBuilder frameOptionsBuilder;
+		private ReferrerPolicyBuilder referrerPolicyBuilder;
+		private StrictTransportSecurityBuilder strictTransportSecurityBuilder;
 
 		internal SecurityHeaderPolicyBuilder()
 		{
-			this.frameOptionsBuilder = new FrameOptionsBuilder();
-			this.referrerPolicyBuilder = new ReferrerPolicyBuilder();
-			this.strictTransportSecurityBuilder = new StrictTransportSecurityBuilder();
+			this.frameOptionsBuilder = SecurityHeaderPolicyDefaults.DefaultFrameOptions();
+			this.referrerPolicyBuilder = SecurityHeaderPolicyDefaults.DefaultReferrerPolicy();
+			this.strictTransportSecurityBuilder = SecurityHeaderPolicyDefaults.DefaultStrictTransportSecurity();
 		}
 
 		/// <summary>Configures the "x-frame-options" header value.</summary>
@@ -27,6 +28,8 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders
 			{
 				throw new ArgumentNullException(nameof(configure));
 			}
+
+			this.frameOptionsBuilder = new FrameOptionsBuilder();
 
 			configure.Invoke(this.frameOptionsBuilder);
 
@@ -44,6 +47,8 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders
 				throw new ArgumentNullException(nameof(configure));
 			}
 
+			this.referrerPolicyBuilder = new ReferrerPolicyBuilder();
+
 			configure.Invoke(this.referrerPolicyBuilder);
 
 			return this;
@@ -60,6 +65,8 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders
 				throw new ArgumentNullException(nameof(configure));
 			}
 
+			this.strictTransportSecurityBuilder = new StrictTransportSecurityBuilder();
+
 			configure.Invoke(this.strictTransportSecurityBuilder);
 
 			return this;
@@ -67,11 +74,20 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders
 
 		internal SecurityHeaderPolicy Build()
 		{
-			return new SecurityHeaderPolicy(
-				"default-src 'self'",
-				this.frameOptionsBuilder.Build(),
-				this.referrerPolicyBuilder.Build(),
-				this.strictTransportSecurityBuilder.Build());
+			var policies = new List<(string, string)>
+			{
+				("content-security-policy", "default-src 'self';frame-ancestors 'none';object-src 'none'"),
+				("x-content-type-options", "nosniff"),
+				("x-frame-options", this.frameOptionsBuilder.Build()),
+				("referrer-policy", this.referrerPolicyBuilder.Build())
+			};
+
+			var secureOnlyPolicies = new List<(string, string)>
+			{
+				("strict-transport-security", this.strictTransportSecurityBuilder.Build())
+			};
+
+			return new SecurityHeaderPolicy(policies.ToArray(), secureOnlyPolicies.ToArray());
 		}
 	}
 }

--- a/src/AdamBarclay.AspNetCore.SecurityHeaders/SecurityHeaderPolicyDefaults.cs
+++ b/src/AdamBarclay.AspNetCore.SecurityHeaders/SecurityHeaderPolicyDefaults.cs
@@ -1,0 +1,35 @@
+using System;
+using AdamBarclay.AspNetCore.SecurityHeaders.PolicyBuilders;
+
+namespace AdamBarclay.AspNetCore.SecurityHeaders
+{
+	internal static class SecurityHeaderPolicyDefaults
+	{
+		internal static FrameOptionsBuilder DefaultFrameOptions()
+		{
+			var frameOptionsBuilder = new FrameOptionsBuilder();
+
+			frameOptionsBuilder.Deny();
+
+			return frameOptionsBuilder;
+		}
+
+		internal static ReferrerPolicyBuilder DefaultReferrerPolicy()
+		{
+			var referrerPolicyBuilder = new ReferrerPolicyBuilder();
+
+			referrerPolicyBuilder.StrictOriginWhenCrossOrigin();
+
+			return referrerPolicyBuilder;
+		}
+
+		internal static StrictTransportSecurityBuilder DefaultStrictTransportSecurity()
+		{
+			var strictTransportSecurityBuilder = new StrictTransportSecurityBuilder();
+
+			strictTransportSecurityBuilder.MaxAge(TimeSpan.FromDays(365)).IncludeSubdomains();
+
+			return strictTransportSecurityBuilder;
+		}
+	}
+}

--- a/tests/AdamBarclay.AspNetCore.SecurityHeaders.Tests/Tests_SecurityHeaderPolicy/WriteHeaders_Writes_Content_Security_Policy_Header.cs
+++ b/tests/AdamBarclay.AspNetCore.SecurityHeaders.Tests/Tests_SecurityHeaderPolicy/WriteHeaders_Writes_Content_Security_Policy_Header.cs
@@ -10,7 +10,9 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders.Tests.Tests_SecurityHeaderPolic
 		{
 			var headers = await TestHarness.Test(app => app.UseSecurityHeaders(o => { }));
 
-			Assert.Equal("default-src 'self'", headers["content-security-policy"]);
+			Assert.Equal(
+				"default-src 'self';frame-ancestors 'none';object-src 'none'",
+				headers["content-security-policy"]);
 		}
 
 		[Fact]
@@ -18,7 +20,9 @@ namespace AdamBarclay.AspNetCore.SecurityHeaders.Tests.Tests_SecurityHeaderPolic
 		{
 			var headers = await TestHarness.Test(app => app.UseSecurityHeaders());
 
-			Assert.Equal("default-src 'self'", headers["content-security-policy"]);
+			Assert.Equal(
+				"default-src 'self';frame-ancestors 'none';object-src 'none'",
+				headers["content-security-policy"]);
 		}
 	}
 }


### PR DESCRIPTION
- Refactor SecurityHeaderPolicy
- Change the way defaults are handled
- Change default content-security-policy to "default-src 'self';frame-ancestors 'none';object-src 'none'"